### PR TITLE
Add WalkIntermediateDirs

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -149,7 +149,7 @@ func (gs *globState) walkDirFunc(fp string, d fs.DirEntry, err error) error {
 		}
 
 		// This non-directory thing doesn't match. Don't return
-		// fs.SkipDir, since that skips the remainder of the directory.
+		// [fs.SkipDir], since that skips the remainder of the directory.
 		gs.logf("non-directory didn't match at all; returning nil\n")
 		return nil
 	}
@@ -195,7 +195,7 @@ func (gs *globState) walkDirFunc(fp string, d fs.DirEntry, err error) error {
 	}
 
 	// Walk the symlink by... recursion.
-	// fs.WalkDir doesn't walk symlinks unless it is the root path... in
+	// [fs.WalkDir] doesn't walk symlinks unless it is the root path... in
 	// which case it does!
 	next := globState{
 		depth:  gs.depth + 1,

--- a/globopts.go
+++ b/globopts.go
@@ -9,11 +9,12 @@ import (
 type GlobOption = func(*globConfig)
 
 type globConfig struct {
-	traverseSymlinks bool
-	translateSlashes bool
-	traceLogger      io.Writer
-	filesystem       fs.FS
-	goroutines       int // only used by MultiGlob
+	traverseSymlinks     bool
+	translateSlashes     bool
+	walkIntermediateDirs bool
+	traceLogger          io.Writer
+	filesystem           fs.FS
+	goroutines           int // only used by MultiGlob
 
 	callback fs.WalkDirFunc // the required arg to Glob
 }
@@ -50,6 +51,22 @@ func TraverseSymlinks(traverse bool) GlobOption {
 func TranslateSlashes(enable bool) GlobOption {
 	return func(cfg *globConfig) {
 		cfg.translateSlashes = enable
+	}
+}
+
+// WalkIntermediateDirs enables or disables calling the walk function with
+// intermediate directory paths (in addition to complete pattern matches).
+// Enabling this is needed in order to skip intermediate directories (by
+// returning fs.SkipDir) based on custom logic in your walk callback.
+// Note that, when enabled, the callback can be called with intermediate
+// directories that ultimately do not contain any completely matching paths.
+// (e.g. when globbing "fixtures/**/*_test", every subdirectory of "fixtures"
+// will be passed to your callback whether or not there is a file named like
+// "*_test" within).
+// Disabled by default.
+func WalkIntermediateDirs(enable bool) GlobOption {
+	return func(cfg *globConfig) {
+		cfg.walkIntermediateDirs = enable
 	}
 }
 

--- a/globopts.go
+++ b/globopts.go
@@ -19,8 +19,8 @@ type globConfig struct {
 	callback fs.WalkDirFunc // the required arg to Glob
 }
 
-// WithFilesystem allows overriding the default filesystem. By default os.DirFS
-// is used to wrap file/directory access in an `fs.FS`.
+// WithFilesystem allows overriding the default filesystem. By default
+// [os.DirFS] is used to wrap file/directory access in an [fs.FS].
 func WithFilesystem(fs fs.FS) GlobOption {
 	return func(cfg *globConfig) {
 		cfg.filesystem = fs
@@ -43,7 +43,7 @@ func TraverseSymlinks(traverse bool) GlobOption {
 	}
 }
 
-// TranslateSlashes enables or disables translating to and from fs.FS paths
+// TranslateSlashes enables or disables translating to and from [fs.FS] paths
 // (always with forward slashes, / ) using filepath.FromSlash. This applies to
 // both the matching pattern and filepaths passed to the callback, and is
 // typically required on Windows. It usually has no effect on systems where
@@ -57,12 +57,22 @@ func TranslateSlashes(enable bool) GlobOption {
 // WalkIntermediateDirs enables or disables calling the walk function with
 // intermediate directory paths (in addition to complete pattern matches).
 // Enabling this is needed in order to skip intermediate directories (by
-// returning fs.SkipDir) based on custom logic in your walk callback.
-// Note that, when enabled, the callback can be called with intermediate
-// directories that ultimately do not contain any completely matching paths.
-// (e.g. when globbing "fixtures/**/*_test", every subdirectory of "fixtures"
-// will be passed to your callback whether or not there is a file named like
-// "*_test" within).
+// returning [fs.SkipDir]) based on custom logic in your walk callback.
+//
+// Note that:
+//
+//   - Intermediate path components from the "pattern root" are not included
+//     (e.g. for the pattern "fixtures/a/b/**", the callback will receive the
+//     path "fixtures/a/b", but not "fixtures" or "fixtures/a".)
+//   - The callback can be called with intermediate directories that ultimately
+//     do _not_ contain any completely matching paths (e.g. when globbing
+//     "fixtures/**/*_test", every subdirectory of "fixtures" will be passed to
+//     your callback whether or not there is a file named like "*_test" anywhere
+//     within).
+//   - However, all intermediate directories seen during the glob
+//     will at least partially match the pattern (e.g. "fixtures/a" partially
+//     matches "fixtures/**/*_test").
+//
 // Disabled by default.
 func WalkIntermediateDirs(enable bool) GlobOption {
 	return func(cfg *globConfig) {

--- a/multiglob.go
+++ b/multiglob.go
@@ -27,9 +27,7 @@ func MultiGlob(ctx context.Context, patterns []*Pattern, f fs.WalkDirFunc, opts 
 	cfg := &globConfig{
 		translateSlashes: true,
 		traverseSymlinks: true,
-		traceLogger:      nil,
 		callback:         f,
-		filesystem:       nil,
 	}
 
 	for _, o := range opts {

--- a/multiglob.go
+++ b/multiglob.go
@@ -11,10 +11,10 @@ import (
 	"sync"
 )
 
-// MultiGlob is like Pattern.Glob, but globs multiple patterns simultaneously.
+// MultiGlob is like [Pattern.Glob], but globs multiple patterns simultaneously.
 // The main idea is to group the patterns by root to avoid multiple different
-// calls to fs.WalkDir (reducing filesystem I/O), and then to use fs.WalkDir on
-// each root in parallel.
+// calls to [fs.WalkDir] (reducing filesystem I/O), and then to use [fs.WalkDir]
+// on each root in parallel.
 // As a result, files can be walked globbed multiple times, but only if distinct
 // overlapping roots appear in different input patterns.
 // You should either make sure that the callback f is safe to call concurrently
@@ -124,7 +124,7 @@ func multiglobWorker(ctx context.Context, cfg *globConfig, workCh <-chan multigl
 						return err
 					}
 				} else {
-					// Assume root sits at that path within the provided fs.FS.
+					// Assume root sits at that path within the provided [fs.FS].
 					fi, err := fs.Stat(cfg.filesystem, root)
 					if err := cfg.callback(osRoot, fs.FileInfoToDirEntry(fi), err); err != nil {
 						if errors.Is(err, fs.SkipDir) || errors.Is(err, fs.SkipAll) {

--- a/multiglob_test.go
+++ b/multiglob_test.go
@@ -79,6 +79,51 @@ func TestMultiGlob_MultiplePatterns_DifferentRoots(t *testing.T) {
 	}
 }
 
+func TestMultiGlob_MultiplePatterns_DifferentRoots_WalkIntermediateDirs(t *testing.T) {
+	patterns := mustMultiParse(t,
+		"fixtures/a/b/cid/**/m",
+		"fixtures/a/b/cod/**/m",
+	)
+
+	var got walkFuncCalls
+	if err := MultiGlob(context.Background(), patterns, got.walkFunc, traceLogOpt, WalkIntermediateDirs(true)); err != nil {
+		t.Fatalf("MultiGlob(...) = %v", err)
+	}
+
+	want := walkFuncCalls{
+		calls: []walkFuncArgs{
+			{Path: "fixtures/a/b/cid"},
+			{Path: "fixtures/a/b/cid/erf"},
+			{Path: "fixtures/a/b/cid/erf/h"},
+			{Path: "fixtures/a/b/cid/erf/h/k"},
+			{Path: "fixtures/a/b/cid/erf/h/k/m"},
+			{Path: "fixtures/a/b/cid/erf/h/k/n"},
+			{Path: "fixtures/a/b/cid/erf/h/k/n/m"},
+			{Path: "fixtures/a/b/cid/erf/i"},
+			{Path: "fixtures/a/b/cid/erf/i/m"},
+			{Path: "fixtures/a/b/cid/erf/i/n"},
+			{Path: "fixtures/a/b/cid/erf/i/n/m"},
+			{Path: "fixtures/a/b/cod"},
+			{Path: "fixtures/a/b/cod/erf"},
+			{Path: "fixtures/a/b/cod/erf/h"},
+			{Path: "fixtures/a/b/cod/erf/h/k"},
+			{Path: "fixtures/a/b/cod/erf/h/k/m"},
+			{Path: "fixtures/a/b/cod/erf/h/k/n"},
+			{Path: "fixtures/a/b/cod/erf/h/k/n/m"},
+			{Path: "fixtures/a/b/cod/erf/i"},
+			{Path: "fixtures/a/b/cod/erf/i/m"},
+			{Path: "fixtures/a/b/cod/erf/i/n"},
+			{Path: "fixtures/a/b/cod/erf/i/n/m"},
+		},
+	}
+
+	got.sortCalls()
+
+	if diff := cmp.Diff(got.calls, want.calls); diff != "" {
+		t.Errorf("walked paths diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestMultiGlob_MultiplePatterns_SameRoot(t *testing.T) {
 	patterns := mustMultiParse(t,
 		"fixtures/a/b/c{i}d/**/m",

--- a/tokeniser.go
+++ b/tokeniser.go
@@ -119,7 +119,7 @@ func tokenise(p string, cfg *parseConfig) *tokens {
 
 		case pathSep:
 			// Always represent the path separator with / for consistency
-			// with io/fs.
+			// with [io/fs].
 			tks = append(tks, literal('/'))
 
 		case '~':


### PR DESCRIPTION
So far, `{Multi,}Glob` tries to be as clever as possible and only provide either complete matches or errors to the callback. That's fine until you want custom logic in the callback that is, say, intended to skip particular intermediate directories by returning `fs.SkipDir`. In that case, the callback never receives the intermediate directory and never has a chance to return `fs.SkipDir`.

This adds a new glob option, `WalkIntermediateDirs`, which causes all the partially matching intermediate directories (including the pattern root) to be passed to the callback (with caveats).