### PR TITLE
Input pattern and opts in DOT comment

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -5,6 +5,8 @@ import "slices"
 type expression interface {
 	// match reports if the rune matches the expression
 	match(rune) bool
+
+	String() string
 }
 
 // Expressions


### PR DESCRIPTION
For better debug-ability, `Pattern` can now be `String`-ed, and the DOT output contains the input pattern and configuration options passed to `Parse`.

This also fixes output DOT syntax where some strings might contain double-quotes, which need escaping in DOT.